### PR TITLE
define x86/x64 features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ windows-sys = { version = "0.60", features = ["Win32_Foundation", "Win32_System_
 lto = true
 codegen-units = 1
 opt-level = 3
+
+[features]
+default = ["x86", "x64"]
+x86 = []
+x64 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,10 @@ mod err;
 
 pub use err::HookError;
 
+#[cfg(feature = "x86")]
 /// The x86 hooker
 pub mod x86;
 
+#[cfg(feature = "x64")]
 /// The x64 hooker
 pub mod x64;


### PR DESCRIPTION
https://github.com/regomne/ilhook-rs/issues/18
Workaround, if we specify only x86 feature of library we can easily skip x64 *win64* requirements during i686-pc-msvc build.
I kept both turned ON by default, as it used to be.