### PR TITLE
Add helpers to register Rust closures as callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,39 @@ the destination address may change by the input arguments.
 
 The EIP will jump to the value the callback routine returns.
 
+# Closure Hooks
+
+This crate provides utility functions for registering hooks that use Rust
+closures as callbacks rather than `extern "C" fn`s. This involves more layers of
+indirection, so it's slightly less efficient, especially when the callbacks
+don't actually close over any data. However, it can be useful if you do have
+additional data, especially since the closure's lifetime is automatically tied
+to the `ClosureHookPoint` that controls when the hook is disposed of.
+
+The closure hook functions are `Hooker::hook_closure_jmp_back`,
+`Hooker::cook_closure_retn`, `Hooker::hook_closure_jmp_to_addr`, and
+`Hooker::hook_closure_jmp_to_ret`. They match the behavior of the four
+`HookType`s.
+
+Here's the same `on_check_sn` example we used above, using a closure hook
+instead:
+
+```rust
+use ilhook::x86::{Hooker, HookType, Registers, CallbackOption, HookFlags};
+
+let on_check_sn = |reg| {
+    println!("m_hash: {}, sn_hash: {}", (*reg).ebx, (*reg).eax);
+    (*reg).eax = (*reg).ebx;
+};
+
+Hooker::hook_closure_jmp_back(
+    0x40107F,
+    on_check_sn,
+    CallbackOption::None,
+    HookFlags::empty(),
+).unwrap();
+```
+
 # Notes
 
 This crate is not thread-safe if you don't specify `HookFlags::NOT_MODIFY_MEMORY_PROTECT`. Of course,

--- a/src/x64.rs
+++ b/src/x64.rs
@@ -220,6 +220,14 @@ pub struct HookPoint {
     flags: HookFlags,
 }
 
+/// The hook result returned by [hook_closure_jmp_back], [hook_closure_retn],
+/// [hook_closure_jmp_to_addr], and [hook_closure_jmp_to_ret]. This ensures
+/// that the closure's lifetime lasts as long as the hook.
+pub struct ClosureHookPoint<T> {
+    _inner: HookPoint,
+    _callback: Box<T>,
+}
+
 #[cfg(not(target_arch = "x86_64"))]
 fn env_lock() {
     panic!("This crate should only be used in arch x86_32!")
@@ -289,6 +297,168 @@ impl Hooker {
             flags: self.flags,
         })
     }
+
+    /// A high-level helper for hooking a function using the [JmpBackRoutine]
+    /// strategy. The [callback] is called before any calls to the function at
+    /// [address], and then the original function is called as normal
+    /// afterwards.
+    ///
+    /// The callback is passed [Registers] that provide access to the original
+    /// function's arguments.
+    ///
+    /// ## Safety
+    ///
+    /// See [hook] for details on when this is safe to call.
+    pub unsafe fn hook_closure_jmp_back<'a, T: Fn(*mut Registers) + Send + Sync + 'a>(
+        address: usize,
+        callback: T,
+        callback_option: CallbackOption,
+        hook_flags: HookFlags,
+    ) -> Result<ClosureHookPoint<T>, HookError> {
+        let callback = Box::new(callback);
+        let hooker = Self::new(
+            address,
+            HookType::JmpBack(run_jmp_back_closure::<T>),
+            callback_option,
+            &*callback as *const T as usize,
+            hook_flags,
+        );
+        Ok(ClosureHookPoint {
+            _inner: unsafe { hooker.hook()? },
+            _callback: callback,
+        })
+    }
+
+    /// A high-level helper for hooking a function using the [RetnRoutine]
+    /// strategy. All calls to the function at [address] are routed to
+    /// [callback] instead, and its return value is used in place of the
+    /// original function's return value.
+    ///
+    /// The callback is passed [Registers] that provide access to the original
+    /// function's arguments, as well as a usize that can be cast to the
+    /// original function's signature using [std::mem::transmute].
+    ///
+    /// ## Safety
+    ///
+    /// See [hook] for details on when this is safe to call.
+    pub unsafe fn hook_closure_retn<
+        'a,
+        T: (Fn(*mut Registers, usize) -> usize) + Send + Sync + 'a,
+    >(
+        address: usize,
+        callback: T,
+        callback_option: CallbackOption,
+        hook_flags: HookFlags,
+    ) -> Result<ClosureHookPoint<T>, HookError> {
+        let callback = Box::new(callback);
+        let hooker = Self::new(
+            address,
+            HookType::Retn(run_retn_closure::<T>),
+            callback_option,
+            &*callback as *const T as usize,
+            hook_flags,
+        );
+        Ok(ClosureHookPoint {
+            _inner: unsafe { hooker.hook()? },
+            _callback: callback,
+        })
+    }
+
+    /// A high-level helper for hooking a function using the [JmpToAddrRoutine]
+    /// strategy. All calls to the function at [address] are routed to
+    /// [callback] instead, then the function at [follow_up] is called and its
+    /// return value is used in place of the original function's.
+    ///
+    /// The callback is passed [Registers] that provide access to the original
+    /// function's arguments, as well as a usize that can be cast to the
+    /// original function's signature using [std::mem::transmute].
+    ///
+    /// ## Safety
+    ///
+    /// See [hook] for details on when this is safe to call.
+    pub unsafe fn hook_closure_jmp_to_addr<'a, T: Fn(*mut Registers, usize) + Send + Sync + 'a>(
+        address: usize,
+        follow_up: usize,
+        callback: T,
+        callback_option: CallbackOption,
+        hook_flags: HookFlags,
+    ) -> Result<ClosureHookPoint<T>, HookError> {
+        let callback = Box::new(callback);
+        let hooker = Self::new(
+            address,
+            HookType::JmpToAddr(follow_up, run_jmp_to_addr_closure::<T>),
+            callback_option,
+            &*callback as *const T as usize,
+            hook_flags,
+        );
+        Ok(ClosureHookPoint {
+            _inner: unsafe { hooker.hook()? },
+            _callback: callback,
+        })
+    }
+
+    /// A high-level helper for hooking a function using the [JmpToRetRoutine]
+    /// strategy. All calls to the function at [address] are routed to
+    /// [callback] instead, then the function at the addressed returned by
+    /// [callback] is called and its return value is used in place of the
+    /// original function's
+    ///
+    /// The callback is passed [Registers] that provide access to the original
+    /// function's arguments, as well as a usize that can be cast to the
+    /// original function's signature using [std::mem::transmute].
+    ///
+    /// ## Safety
+    ///
+    /// See [hook] for details on when this is safe to call.
+    pub unsafe fn hook_closure_jmp_to_ret<
+        'a,
+        T: (Fn(*mut Registers, usize) -> usize) + Send + Sync + 'a,
+    >(
+        address: usize,
+        callback: T,
+        callback_option: CallbackOption,
+        hook_flags: HookFlags,
+    ) -> Result<ClosureHookPoint<T>, HookError> {
+        let callback = Box::new(callback);
+        let hooker = Self::new(
+            address,
+            HookType::JmpToRet(run_retn_closure::<T>),
+            callback_option,
+            &*callback as *const T as usize,
+            hook_flags,
+        );
+        Ok(ClosureHookPoint {
+            _inner: unsafe { hooker.hook()? },
+            _callback: callback,
+        })
+    }
+}
+
+/// The userdata trampoline for [Hooker::hook_closure_jmp_back].
+unsafe extern "win64" fn run_jmp_back_closure<T: Fn(*mut Registers)>(
+    reg: *mut Registers,
+    callback: usize,
+) {
+    unsafe { (*(callback as *const T))(reg) };
+}
+
+/// The userdata trampoline for [Hooker::hook_closure_retn] *and*
+/// [Hooker::hook_closure_jmp_to_ret].
+unsafe extern "win64" fn run_retn_closure<T: Fn(*mut Registers, usize) -> usize>(
+    reg: *mut Registers,
+    original: usize,
+    callback: usize,
+) -> usize {
+    unsafe { (*(callback as *const T))(reg, original) }
+}
+
+/// The userdata trampoline for [Hooker::hook_closure_jmp_to_addr].
+unsafe extern "win64" fn run_jmp_to_addr_closure<T: Fn(*mut Registers, usize)>(
+    reg: *mut Registers,
+    original: usize,
+    callback: usize,
+) {
+    unsafe { (*(callback as *const T))(reg, original) };
 }
 
 impl HookPoint {


### PR DESCRIPTION
These helpers have a little more indirection than the raw hooking API, but they make it much easier to share data with the callback or to wrap it further in an API with known argument types.

Closes #21 